### PR TITLE
fix: Webデモの画像処理とPython実行機能を改善

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -108,6 +108,7 @@
     </div>
 
     <script src="static/wasm_exec.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
     <script src="static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Webデモページの画像処理エラーを修正し、Pyodideを統合してブラウザ上でPythonコードを実行できるように改善しました。

## 修正・改善内容

### 1. 画像デコードエラーの修正
- Base64エンコーディングの処理を修正
- FileReaderの代わりにArrayBufferを使用してより確実な変換を実装
- 画像データを正しくWebAssemblyに渡せるように修正

### 2. サンプル画像の配置
- 既存のexample画像をサンプルディレクトリにコピー
- hello-world.png、calculator.png、fibonacci.png、loop.pngを配置

### 3. Pyodide統合によるPython実行機能
- Pyodideを統合し、ブラウザ上でPythonコードを実行可能に
- 生成されたPythonコードが実際に実行され、結果が表示される
- 実行エラーも適切にキャッチして表示

## 変更前後の動作

### Before
- 画像選択時: `Failed to detect program: failed to decode image: image: unknown format`エラー
- 実行時: `Python execution in browser requires Pyodide integration`メッセージ

### After
- 画像が正しく処理される
- Pythonコードが実行され、実際の出力結果が表示される

## Test plan
- [x] サンプル画像が正しく表示されることを確認
- [x] 画像選択・アップロード時にデコードエラーが発生しないことを確認
- [x] Pythonコードが実行され、結果が表示されることを確認
- [x] 実行エラーが適切に表示されることを確認

## Related PR
Improves PR #22

🤖 Generated with [Claude Code](https://claude.ai/code)