### PR TITLE
fix: WebデモのWASMビルドをGo 1.23に更新

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
           
       - name: Build WebAssembly
         run: |


### PR DESCRIPTION
## 概要
WebデモでValueOfパニックエラーが発生する問題を修正

## 問題
- デプロイされたWebデモで画像を選択して実行すると`panic: ValueOf: invalid value`エラーが発生
- 原因: Go 1.21.13でビルドされたWASMがGo/JavaScript間の値の受け渡しで互換性問題を起こしている

## 修正内容
- deploy-web.ymlのGoバージョンを1.21から1.23に更新
- これによりsyscall/jsの互換性問題が解決されます

## テスト
- GitHub Actionsでの自動デプロイ後に動作確認が必要

🤖 Generated with [Claude Code](https://claude.ai/code)