### PR TITLE
fix: test-wasm.jsをdebugオブジェクト形式に対応

### DIFF
--- a/.github/workflows/test-web-deploy.yml
+++ b/.github/workflows/test-web-deploy.yml
@@ -1,0 +1,75 @@
+name: Test Web Deployment
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - 'cmd/grimoire-wasm/**'
+      - '.github/workflows/deploy-web.yml'
+      - '.github/workflows/test-web-deploy.yml'
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          
+      - name: Verify Go version for WASM compatibility
+        run: |
+          go version
+          echo "Ensuring Go 1.23 is used for WASM build..."
+          GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
+          echo "Go version: $GO_VERSION"
+          
+      - name: Setup Node.js for testing
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Build WebAssembly
+        run: |
+          cd web
+          chmod +x build-wasm.sh
+          ./build-wasm.sh
+          
+      - name: Install test dependencies
+        run: |
+          cd web
+          npm init -y
+          npm install --save-dev node-fetch@2 jsdom
+          
+      - name: Test WASM before deployment
+        run: |
+          cd web
+          echo "Running WASM tests to ensure build is successful..."
+          node test-wasm.js
+          
+      - name: Verify WASM artifacts
+        run: |
+          cd web
+          echo "Checking WASM build artifacts..."
+          ls -la static/wasm/grimoire.wasm
+          ls -la static/wasm_exec.js
+          WASM_SIZE=$(stat -c%s static/wasm/grimoire.wasm)
+          echo "WASM file size: $WASM_SIZE bytes"
+          if [ $WASM_SIZE -lt 1000000 ]; then
+            echo "Error: WASM file is too small, build may have failed"
+            exit 1
+          fi
+          
+      - name: Summary
+        run: |
+          echo "✅ Web deployment tests passed!"
+          echo "The following checks were successful:"
+          echo "- Go 1.23 is properly installed"
+          echo "- WASM build completed successfully"
+          echo "- WASM tests passed"
+          echo "- WASM file size is valid"
+          echo ""
+          echo "This PR is ready for deployment to GitHub Pages."

--- a/.github/workflows/test-web-deploy.yml
+++ b/.github/workflows/test-web-deploy.yml
@@ -34,9 +34,23 @@ jobs:
           
       - name: Build WebAssembly
         run: |
+          echo "Current directory: $(pwd)"
+          echo "Directory contents:"
+          ls -la
+          echo "Web directory contents:"
+          ls -la web/
+          echo "Building WASM..."
           cd web
           chmod +x build-wasm.sh
-          ./build-wasm.sh
+          # ビルドスクリプトの内容を表示
+          echo "Build script contents:"
+          cat build-wasm.sh
+          # Goモジュールの依存関係を取得
+          cd ..
+          go mod download
+          cd web
+          # ビルドを実行
+          ./build-wasm.sh || (echo "Build failed with exit code $?"; exit 1)
           
       - name: Install test dependencies
         run: |

--- a/web/test-wasm.js
+++ b/web/test-wasm.js
@@ -174,26 +174,23 @@ async function runTests() {
         const jsonStr = JSON.stringify(result3);
         assert(!jsonStr.includes('null') || result3.ast === null, 'Should not have unexpected null values');
         
-        // debugInfoがある場合、それがJSON文字列であることを確認
+        // debugInfoがある場合、それがオブジェクトであることを確認
         if (result3.debug) {
-            assert(typeof result3.debug === 'string', 'debug should be a JSON string');
-            try {
-                const debugObj = JSON.parse(result3.debug);
-                assert(typeof debugObj === 'object', 'debug should be parseable as JSON');
-            } catch (e) {
-                assert(false, 'debug should be valid JSON: ' + e.message);
+            assert(typeof result3.debug === 'object', 'debug should be an object');
+            assert(result3.debug !== null, 'debug should not be null');
+            // symbolCountとsymbolsが存在することを確認
+            if (result3.debug.symbolCount !== undefined) {
+                assert(typeof result3.debug.symbolCount === 'number', 'symbolCount should be a number');
+            }
+            if (result3.debug.symbols !== undefined) {
+                assert(Array.isArray(result3.debug.symbols), 'symbols should be an array');
             }
         }
         
-        // astがある場合、それがJSON文字列であることを確認
+        // astがある場合、それがオブジェクトであることを確認
         if (result3.ast) {
-            assert(typeof result3.ast === 'string', 'ast should be a JSON string');
-            try {
-                const astObj = JSON.parse(result3.ast);
-                assert(typeof astObj === 'object', 'ast should be parseable as JSON');
-            } catch (e) {
-                assert(false, 'ast should be valid JSON: ' + e.message);
-            }
+            assert(typeof result3.ast === 'object', 'ast should be an object');
+            assert(result3.ast !== null, 'ast should not be null');
         }
         
         // JavaScriptに渡せない値が含まれていないか確認（ValueOfエラーの原因となる値）
@@ -255,7 +252,11 @@ async function runTests() {
         
         // debugInfoの詳細な検証
         if (complexResult.debug) {
-            const debugObj = JSON.parse(complexResult.debug);
+            // debugがJSON文字列の場合はパース、オブジェクトの場合はそのまま使用
+            let debugObj = complexResult.debug;
+            if (typeof debugObj === 'string') {
+                debugObj = JSON.parse(debugObj);
+            }
             
             // シンボルが検出された場合の検証
             if (debugObj.symbolCount > 0) {
@@ -349,7 +350,11 @@ async function runTests() {
         const result = global.processGrimoireImage(testImage);
         
         if (result.debug) {
-            const debugObj = JSON.parse(result.debug);
+            // debugがJSON文字列の場合はパース、オブジェクトの場合はそのまま使用
+            let debugObj = result.debug;
+            if (typeof debugObj === 'string') {
+                debugObj = JSON.parse(debugObj);
+            }
             
             // symbolCountが数値であることを確認
             assert(typeof debugObj.symbolCount === 'number', 'symbolCount should be a number, not a Go int');


### PR DESCRIPTION
- debugとastがオブジェクトとして返されるように変更された最新の実装に合わせてテストを修正
- JSON文字列とオブジェクトの両方に対応できるように互換性を保持
- PR用のテストワークフローを追加してデプロイ前にビルドとテストを検証

🤖 Generated with [Claude Code](https://claude.ai/code)