### PR TITLE
fix: デプロイワークフローの依存関係問題を修正

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -43,8 +43,6 @@ jobs:
           
       - name: Build WebAssembly
         run: |
-          # Goモジュールの依存関係を先に取得
-          go mod download
           cd web
           chmod +x build-wasm.sh
           ./build-wasm.sh

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -43,6 +43,8 @@ jobs:
           
       - name: Build WebAssembly
         run: |
+          # Goモジュールの依存関係を先に取得
+          go mod download
           cd web
           chmod +x build-wasm.sh
           ./build-wasm.sh

--- a/.github/workflows/test-web-deploy.yml
+++ b/.github/workflows/test-web-deploy.yml
@@ -34,23 +34,9 @@ jobs:
           
       - name: Build WebAssembly
         run: |
-          echo "Current directory: $(pwd)"
-          echo "Directory contents:"
-          ls -la
-          echo "Web directory contents:"
-          ls -la web/
-          echo "Building WASM..."
           cd web
           chmod +x build-wasm.sh
-          # ビルドスクリプトの内容を表示
-          echo "Build script contents:"
-          cat build-wasm.sh
-          # Goモジュールの依存関係を取得
-          cd ..
-          go mod download
-          cd web
-          # ビルドを実行
-          ./build-wasm.sh || (echo "Build failed with exit code $?"; exit 1)
+          ./build-wasm.sh
           
       - name: Install test dependencies
         run: |

--- a/web/build-wasm.sh
+++ b/web/build-wasm.sh
@@ -7,16 +7,27 @@ set -e
 
 echo "Building Grimoire for WebAssembly..."
 
-# wasmディレクトリに移動
-cd "$(dirname "$0")"
+# スクリプトのディレクトリに移動
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# プロジェクトルートに移動してGo依存関係をダウンロード
+echo "Downloading Go dependencies..."
+cd ..
+go mod download
+
+# webディレクトリに戻る
+cd web
 
 # Go WebAssemblyサポートファイルをコピー
+echo "Copying wasm_exec.js..."
 cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" static/
 
 # wasmディレクトリを作成
 mkdir -p static/wasm
 
 # WebAssemblyバイナリをビルド
+echo "Building WASM binary..."
 GOOS=js GOARCH=wasm go build -o static/wasm/grimoire.wasm ../cmd/grimoire-wasm/main.go
 
 echo "Build complete!"


### PR DESCRIPTION
## Summary
- 本番デプロイでのビルド失敗を修正
- テストと本番のビルドプロセスを完全に統一

## 問題の原因と解決策
### 問題
- test-web-deploy.ymlには`go mod download`があるのに、deploy-web.ymlにはなかった
- テストワークフローと本番ワークフローでビルドプロセスが異なっていた

### 解決策
**ビルドスクリプトにすべての必要なステップを統合**しました。

## 変更内容
1. `build-wasm.sh`に`go mod download`を追加
2. 両方のワークフローから重複した処理を削除
3. テストワークフローのデバッグ情報を削除

## 結果
- ローカル開発、テスト、本番デプロイのすべてで同じビルドプロセスが実行される
- テストで成功したものが本番でも確実に成功する
- ビルドプロセスの変更が1箇所（build-wasm.sh）で管理できる

## 動作確認
```bash
cd web && ./build-wasm.sh
```
上記コマンドでローカルでのビルド成功を確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)